### PR TITLE
Small change in 3A - Added a new configOption

### DIFF
--- a/3a/SiloHost/src/Program.cs
+++ b/3a/SiloHost/src/Program.cs
@@ -47,6 +47,7 @@ namespace SiloHost
                         {
                             options.UseJson = true;
                             options.Service = "us-west-2";
+                            options.TableName = "grainPersistenceTable";
                         });
                     siloBuilder.ConfigureApplicationParts(applicationPartManager =>
                         applicationPartManager.AddApplicationPart(typeof(HelloWorld).Assembly).WithReferences());


### PR DESCRIPTION
## SiloHost/src/Program.cs
      Currently, Grain persistence defaults to an existing dynamoDb table 'OrleansGrainState' for all users.
      Change here, would allow persistence to a new table that user provides.

