### PR TITLE
Use valuetask instead of Task.FromResult

### DIFF
--- a/2/Grains/src/HelloWorld.cs
+++ b/2/Grains/src/HelloWorld.cs
@@ -5,9 +5,9 @@ namespace Grains
 {
     public class HelloWorld : Orleans.Grain, IHelloWorld
     {
-        public Task<string> SayHello(string name)
+        public ValueTask<string> SayHello(string name)
         {
-            return Task.FromResult($@"Hello {name}!");
+          return new ValueTask<string> ($@"Hello {name}!");
         }
-    }
+  }
 }

--- a/2/Interfaces/src/IHelloWorld.cs
+++ b/2/Interfaces/src/IHelloWorld.cs
@@ -4,6 +4,6 @@ namespace Interfaces
 {
     public interface IHelloWorld : Orleans.IGrainWithIntegerKey
     {
-        Task<string> SayHello(string name);
+        ValueTask<string> SayHello(string name);
     }
 }


### PR DESCRIPTION
A trivial change to introduce ValueTask instead of Task.FromResult. In this case being completely synchronous, the code shouldn't allocate anything, instead of allocating one Task.

 If we agree on the changes, I'll propagate them across the various solutions