### PR TITLE
Fetching only the first IP address from ifconfig

### DIFF
--- a/3/run-client-docker.sh
+++ b/3/run-client-docker.sh
@@ -2,7 +2,7 @@
 
 # 2020-12-07 PJ:
 # Code below gets local IP for dockerized applications to function and communicate correctly.
-ADVERTISEDIP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | grep -m1 ""`
+ADVERTISEDIP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v -m1 '127.0.0.1'`
 GATEWAYPORT=3000
 
 docker build -t client -f ./ops/Client/Dockerfile ./ &&

--- a/3/run-silo-docker.sh
+++ b/3/run-silo-docker.sh
@@ -2,7 +2,7 @@
 
 # 2020-12-07 PJ:
 # Code below gets local IP for dockerized applications to function and communicate correctly.
-ADVERTISEDIP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | grep -m1 ""`
+ADVERTISEDIP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v -m1 '127.0.0.1'`
 GATEWAYPORT=3000
 
 docker build -t silo-host -f ./ops/SiloHost/Dockerfile ./ &&

--- a/3a/run-client-docker.sh
+++ b/3a/run-client-docker.sh
@@ -2,7 +2,7 @@
 
 # 2020-12-07 PJ:
 # Code below gets local IP for dockerized applications to function and communicate correctly.
-ADVERTISEDIP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1'`
+ADVERTISEDIP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v -m1 '127.0.0.1'`
 GATEWAYPORT=3000
 
 docker build -t client -f ./ops/Client/Dockerfile ./ &&

--- a/3a/run-silo-docker.sh
+++ b/3a/run-silo-docker.sh
@@ -2,7 +2,7 @@
 
 # 2020-12-07 PJ:
 # Code below gets local IP for dockerized applications to function and communicate correctly.
-ADVERTISEDIP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1'`
+ADVERTISEDIP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v -m1 '127.0.0.1'`
 GATEWAYPORT=3000
 
 docker build -t silo-host -f ./ops/SiloHost/Dockerfile ./ &&

--- a/3b/run-client-docker.sh
+++ b/3b/run-client-docker.sh
@@ -2,7 +2,7 @@
 
 # 2020-12-07 PJ:
 # Code below gets local IP for dockerized applications to function and communicate correctly.
-ADVERTISEDIP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1'`
+ADVERTISEDIP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v -m1 '127.0.0.1'`
 GATEWAYPORT='3000'
 
 docker build -t client -f ./ops/Client/Dockerfile ./ &&

--- a/3b/run-silo-docker.sh
+++ b/3b/run-silo-docker.sh
@@ -2,7 +2,7 @@
 
 # 2020-12-07 PJ:
 # Code below gets local IP for dockerized applications to function and communicate correctly.
-ADVERTISEDIP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1'`
+ADVERTISEDIP=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v -m1 '127.0.0.1'`
 GATEWAYPORT='3000'
 DASHBOARDPORT='8080'
 DATADOG_SERVICE_NAME='road-to-orleans-3b'


### PR DESCRIPTION
I had both wifi and cable connectivity, and the docker scripts were failing, because the IP detection code was returning two IP addresses
![image](https://user-images.githubusercontent.com/2494505/137739403-b6eb6bac-f25d-4dcc-b1ba-b67b76e37027.png)

Piping the result to `grep -m1 ""` will pick the first result
![image](https://user-images.githubusercontent.com/2494505/137739717-8f16aa9c-dd54-4dee-81c4-5b29d1c6ff0c.png)

 If we agree on the changes, I'll propagate them across the various solutions