### PR TITLE
Fix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 # This is a fix for users using Windows and unix systems
+# See: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#per-repository-settings
 * text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+# This is a fix for users using Windows and unix systems
+* text=auto


### PR DESCRIPTION
Found that we don't have a line ending normalizer between macOS and Windows. 
See https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#per-repository-settings for more information.