### PR TITLE
Adding client retries

### DIFF
--- a/5a/Client/src/Program.fs
+++ b/5a/Client/src/Program.fs
@@ -85,7 +85,7 @@ let main _args =
     client.Connect
         (fun error ->
             task {
-                Async.Sleep(TimeSpan.FromSeconds(1)) |> Async.RunSynchronously
+                do! Async.Sleep(TimeSpan.FromSeconds(1))
                 attempts <- attempts + 1
                 printfn $"Failed to connect to cluster on attempt {attempts} of {maxAttempts}"
 

--- a/5a/Client/src/Program.fs
+++ b/5a/Client/src/Program.fs
@@ -96,7 +96,10 @@ let main _args =
     |> Async.AwaitTask
     |> Async.RunSynchronously
 
-    let grain = client.GetGrain<IHelloWorld>(0)
+    // Generate random grain number key
+    let key = (Random().Next() % 100)
+    
+    let grain = client.GetGrain<IHelloWorld>(key)
     grain.SayHello("Popcorn!")
     |> Async.AwaitTask
     |> Async.RunSynchronously

--- a/5a/Client/src/Program.fs
+++ b/5a/Client/src/Program.fs
@@ -2,7 +2,6 @@ open System
 open System.Net
 open System.Net.NetworkInformation
 open System.Net.Sockets
-open System.Threading.Tasks
 open Interfaces
 open Microsoft.Extensions.Logging
 open Orleans

--- a/5a/Client/src/Program.fs
+++ b/5a/Client/src/Program.fs
@@ -76,7 +76,7 @@ let main _args =
             .UseStaticClustering(IPEndPoint(ipAddress, gatewayPort))
             .ConfigureLogging(fun (builder: ILoggingBuilder) ->
                 builder
-                    .SetMinimumLevel(LogLevel.Warning)
+                    .SetMinimumLevel(LogLevel.Information)
                     .AddConsole()
                 |> ignore)
             .Build()


### PR DESCRIPTION
Added the retry mechanism to the Orleans connection.
![Screen Shot 2022-01-31 at 15 06 43](https://user-images.githubusercontent.com/2493377/151818193-a95eb948-6013-4103-bd59-b7dc4cab9373.png)

For the screenshot above, I set the logger to the `Warning` level in order to show the retries.