### PR TITLE
4b add testresult (added skeleton to display UnitTestResult & TestList)

### DIFF
--- a/4b/Grains/src/Coordinator.cs
+++ b/4b/Grains/src/Coordinator.cs
@@ -38,12 +38,26 @@ namespace Grains
             testRun.Times.Start = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);
             testRun.Times.Queuing = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);
 
+            testRun.TestLists = new List<TestList>()
+            {
+                new TestList()
+                {
+                    Name = "Results Not in a List",
+                    Id = Guid.NewGuid().ToString()
+                },
+                new TestList()
+                {
+                    Name = "All Loaded Results",
+                    Id = Guid.NewGuid().ToString()
+                }
+            };
+            
             testRun.TestDefinitions = new TestDefinitions()
             {
-                UnitTests = new List<UnitTest>()
+                UnitTests = new List<UnitTestDefinition>()
             };
 
-            var tests = new List<Task<UnitTest>>
+            var tests = new List<Task<TestDetails>>
             {
                 GrainFactory.GetGrain<ITest1>(1).HelloWorldTest(),
                 GrainFactory.GetGrain<ITest2>(2).HelloWorldTest(),
@@ -56,7 +70,8 @@ namespace Grains
             };
 
             await Task.WhenAll(tests);
-            testRun.TestDefinitions.UnitTests = tests.Select(t => t.Result).ToList();
+            var testDetailsResult = tests.Select(t => t.Result);
+            testRun.TestDefinitions.UnitTests = testDetailsResult.Select(tdr => tdr.UnitTestDefinition).ToList();
             testRun.Times.Finish = DateTime.UtcNow.ToString(CultureInfo.InvariantCulture);
             
             stopwatch.Stop();

--- a/4b/Grains/src/Test1.cs
+++ b/4b/Grains/src/Test1.cs
@@ -6,7 +6,7 @@ namespace Grains
 {
     public class Test1 : Orleans.Grain, ITest1
     {
-        public async Task<UnitTest> HelloWorldTest()
+        public async Task<TestDetails> HelloWorldTest()
         {
             await Task.Delay(100);
             var unitTest = Helpers.UnitTestCreator(this.GetType(), Helpers.CallerName());

--- a/4b/Grains/src/Test2.cs
+++ b/4b/Grains/src/Test2.cs
@@ -6,7 +6,7 @@ namespace Grains
 {
     public class Test2 : Orleans.Grain, ITest2
     {
-        public async Task<UnitTest> HelloWorldTest()
+        public async Task<TestDetails> HelloWorldTest()
         {
             await Task.Delay(200);
             var unitTest = Helpers.UnitTestCreator(this.GetType(), Helpers.CallerName());

--- a/4b/Interfaces/Helpers.cs
+++ b/4b/Interfaces/Helpers.cs
@@ -11,13 +11,13 @@ namespace Interfaces
             return name;
         }
 
-        public static UnitTest UnitTestCreator(Type classType, string callerName )
+        public static TestDetails UnitTestCreator(Type classType, string callerName )
         {
             var methodName = callerName;
             var classFullName = classType.FullName;
             var assemblyName = classType.Assembly.GetName();
             
-            var unitTest = new UnitTest()
+            var unitTest = new UnitTestDefinition()
             {
                 Id = Guid.NewGuid().ToString(),
                 Execution = new Execution()
@@ -34,7 +34,17 @@ namespace Interfaces
                     CodeBase = $"{assemblyName.Name}.dll"
                 }
             };
-            return unitTest;
+
+            var unitTestResult = new UnitTestResult()
+            {
+
+            };
+
+            return new TestDetails()
+            {
+                UnitTestDefinition = unitTest,
+                UnitTestResult = unitTestResult
+            };
         }
     }
 }

--- a/4b/Interfaces/src/ITest1.cs
+++ b/4b/Interfaces/src/ITest1.cs
@@ -5,6 +5,6 @@ namespace Interfaces
 {
     public interface ITest1 : Orleans.IGrainWithIntegerKey
     {
-        Task<UnitTest> HelloWorldTest();
+        Task<TestDetails> HelloWorldTest();
     }
 }

--- a/4b/Interfaces/src/ITest2.cs
+++ b/4b/Interfaces/src/ITest2.cs
@@ -5,6 +5,6 @@ namespace Interfaces
 {
     public interface ITest2 : Orleans.IGrainWithIntegerKey
     {
-        Task<UnitTest> HelloWorldTest();
+        Task<TestDetails> HelloWorldTest();
     }
 }

--- a/4b/Interfaces/src/TRX/Results.cs
+++ b/4b/Interfaces/src/TRX/Results.cs
@@ -7,9 +7,10 @@ namespace Interfaces.src.TRX
     public class Results
     {
         [XmlElement(ElementName = "UnitTestResult")]
-        public List<UnitTestResult> UnitTestResult { get; set; }
+        public List<UnitTestResult> UnitTestResults { get; set; }
     }
     
+    [XmlRoot(ElementName = "UnitTestResult")]
     public class UnitTestResult
     {
         [XmlAttribute(AttributeName = "executionId")]

--- a/4b/Interfaces/src/TRX/TestDefinitions.cs
+++ b/4b/Interfaces/src/TRX/TestDefinitions.cs
@@ -8,11 +8,11 @@ namespace Interfaces.src.TRX
     public class TestDefinitions
     {
         [XmlElement(ElementName = "UnitTest")]
-        public List<UnitTest> UnitTests { get; set; }
+        public List<UnitTestDefinition> UnitTests { get; set; }
     }
 
     [XmlRoot(ElementName = "UnitTest")]
-    public class UnitTest
+    public class UnitTestDefinition
     {
         [XmlAttribute(AttributeName = "id")]
         public string Id { get; set; }

--- a/4b/Interfaces/src/TRX/TestDetails.cs
+++ b/4b/Interfaces/src/TRX/TestDetails.cs
@@ -1,0 +1,8 @@
+namespace Interfaces.src.TRX
+{
+    public class TestDetails
+    {
+        public UnitTestResult UnitTestResult { get; set; }
+        public UnitTestDefinition UnitTestDefinition { get; set; }
+    }
+}

--- a/4b/Interfaces/src/TRX/TestResults.cs
+++ b/4b/Interfaces/src/TRX/TestResults.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace Interfaces.src.TRX
+{
+    [XmlRoot(ElementName = "Results")]
+    public class Results
+    {
+        [XmlElement(ElementName = "UnitTestResult")]
+        public List<UnitTestResult> UnitTestResult { get; set; }
+    }
+    
+    public class UnitTestResult
+    {
+        [XmlAttribute(AttributeName = "executionId")]
+        public string ExecutionId { get; set; }
+
+        [XmlAttribute(AttributeName = "testId")]
+        public string TestId { get; set; }
+
+        [XmlAttribute(AttributeName = "testName")]
+        public string TestName { get; set; }
+
+        [XmlAttribute(AttributeName = "computerName")]
+        public string ComputerName { get; set; }
+
+        [XmlAttribute(AttributeName = "duration")]
+        public string Duration { get; set; }
+
+        [XmlAttribute(AttributeName = "startTime")]
+        public string StartTime { get; set; }
+
+        [XmlAttribute(AttributeName = "endTime")]
+        public string EndTime { get; set; }
+
+        [XmlAttribute(AttributeName = "testType")]
+        public string TestType { get; set; }
+
+        [XmlAttribute(AttributeName = "outcome")]
+        public string Outcome { get; set; }
+
+        [XmlAttribute(AttributeName = "testListId")]
+        public string TestListId { get; set; }
+
+        [XmlAttribute(AttributeName = "relativeResultsDirectory")]
+        public string RelativeResultsDirectory { get; set; }
+    }
+}

--- a/4b/Interfaces/src/TRX/TestRun.cs
+++ b/4b/Interfaces/src/TRX/TestRun.cs
@@ -61,50 +61,7 @@ namespace Interfaces.src.TRX
         [XmlAttribute(AttributeName = "runDeploymentRoot")]
         public string RunDeploymentRoot { get; set; }
     }
-
-    [XmlRoot(ElementName = "Results")]
-    public class Results
-    {
-        [XmlElement(ElementName = "UnitTestResult")]
-        public List<UnitTestResult> UnitTestResult { get; set; }
-    }
-
-    public class UnitTestResult
-    {
-        [XmlAttribute(AttributeName = "executionId")]
-        public string ExecutionId { get; set; }
-
-        [XmlAttribute(AttributeName = "testId")]
-        public string TestId { get; set; }
-
-        [XmlAttribute(AttributeName = "testName")]
-        public string TestName { get; set; }
-
-        [XmlAttribute(AttributeName = "computerName")]
-        public string ComputerName { get; set; }
-
-        [XmlAttribute(AttributeName = "duration")]
-        public string Duration { get; set; }
-
-        [XmlAttribute(AttributeName = "startTime")]
-        public string StartTime { get; set; }
-
-        [XmlAttribute(AttributeName = "endTime")]
-        public string EndTime { get; set; }
-
-        [XmlAttribute(AttributeName = "testType")]
-        public string TestType { get; set; }
-
-        [XmlAttribute(AttributeName = "outcome")]
-        public string Outcome { get; set; }
-
-        [XmlAttribute(AttributeName = "testListId")]
-        public string TestListId { get; set; }
-
-        [XmlAttribute(AttributeName = "relativeResultsDirectory")]
-        public string RelativeResultsDirectory { get; set; }
-    }
-
+    
     public class ResultSummary
     {
         [XmlElement(ElementName = "Counters")]


### PR DESCRIPTION
1. Added placeholder for TestLists to Coordinator
2. Modified UnitTestCreator to return TestDetails object that contain TestDefinitions and UnitTestResult objects
3. Modified Test1, Test2 and Coordinator to reflect changes in the UnitTestCreator
4. Move UnitTestResult class from TestRun.cs into its own file TestResults.cs
5. Minor changes to naming for readability