### PR TITLE
Fix docker expose port for 3c

### DIFF
--- a/3c/SiloHost/src/Program.cs
+++ b/3c/SiloHost/src/Program.cs
@@ -29,7 +29,7 @@ namespace SiloHost
                 {
                     webHostBuilder
                         .UseStartup<Startup>()
-                        .UseUrls("http://localhost:5000");
+                        .UseUrls("http://*:5000");
                 })
                 .UseOrleans(siloBuilder =>
                 {


### PR DESCRIPTION
There was a small trick we need to fix in order to get the API running in docker. We need to listen from everywhere and not just `localhost`. Changing it to `*` fixes that.
![Screen Shot 2022-02-07 at 16 28 00](https://user-images.githubusercontent.com/2493377/152830068-d53c4cb8-2882-465e-90e5-c36a72b1dccc.png)
