### PR TITLE
Introducing Docker compose

### DIFF
--- a/5a/docker-compose-2Silos-1Client.yml
+++ b/5a/docker-compose-2Silos-1Client.yml
@@ -23,6 +23,10 @@ services:
       - GATEWAYPORT=3003
       - PRIMARYPORT=2001
       - DASHBOARDPORT=8083
+    ports:
+      - "8083:8083"
+      - "3003:3003"
+      - "2003:2003"
   orleans-silo:
     image: orleans-silo
     build:

--- a/5a/docker-compose-2Silos-1Client.yml
+++ b/5a/docker-compose-2Silos-1Client.yml
@@ -1,3 +1,5 @@
+version: '3.1'
+
 services:
   orleans-client:
     image: orleans-client
@@ -9,6 +11,18 @@ services:
       - GATEWAYPORT=3001
     depends_on: 
       - orleans-silo
+      - orleans-silotwo
+  orleans-silotwo:
+    image: orleans-silo
+    build:
+      context: .
+      dockerfile: ./ops/SiloHost/Dockerfile
+    environment:
+      - ADVERTISEDIP=172.17.0.1
+      - SILOPORT=2003
+      - GATEWAYPORT=3003
+      - PRIMARYPORT=2001
+      - DASHBOARDPORT=8083
   orleans-silo:
     image: orleans-silo
     build:

--- a/5a/docker-compose-3Silos-1Client.yml
+++ b/5a/docker-compose-3Silos-1Client.yml
@@ -1,0 +1,52 @@
+version: '3.1'
+
+services:
+  orleans-client:
+    image: orleans-client
+    build:
+      context: .
+      dockerfile: ./ops/Client/Dockerfile
+    environment:
+      - ADVERTISEDIP=172.17.0.1
+      - GATEWAYPORT=3001
+    depends_on:
+      - orleans-silo
+      - orleans-silotwo
+      - orleans-silothree
+  orleans-silothree:
+    image: orleans-silo
+    build:
+      context: .
+      dockerfile: ./ops/SiloHost/Dockerfile
+    environment:
+      - ADVERTISEDIP=172.17.0.1
+      - SILOPORT=2004
+      - GATEWAYPORT=3004
+      - PRIMARYPORT=2001
+      - DASHBOARDPORT=8084
+  orleans-silotwo:
+    image: orleans-silo
+    build:
+      context: .
+      dockerfile: ./ops/SiloHost/Dockerfile
+    environment:
+      - ADVERTISEDIP=172.17.0.1
+      - SILOPORT=2003
+      - GATEWAYPORT=3003
+      - PRIMARYPORT=2001
+      - DASHBOARDPORT=8083
+  orleans-silo:
+    image: orleans-silo
+    build:
+      context: .
+      dockerfile: ./ops/SiloHost/Dockerfile
+    environment:
+      - ADVERTISEDIP=172.17.0.1
+      - SILOPORT=2001
+      - GATEWAYPORT=3001
+      - PRIMARYPORT=2001
+      - DASHBOARDPORT=8081
+    ports:
+      - "8081:8081"
+      - "3001:3001"
+      - "2001:2001"

--- a/5a/docker-compose-3Silos-1Client.yml
+++ b/5a/docker-compose-3Silos-1Client.yml
@@ -24,6 +24,10 @@ services:
       - GATEWAYPORT=3004
       - PRIMARYPORT=2001
       - DASHBOARDPORT=8084
+    ports:
+      - "8084:8084"
+      - "3004:3004"
+      - "2004:2004"
   orleans-silotwo:
     image: orleans-silo
     build:
@@ -35,6 +39,10 @@ services:
       - GATEWAYPORT=3003
       - PRIMARYPORT=2001
       - DASHBOARDPORT=8083
+    ports:
+      - "8083:8083"
+      - "3003:3003"
+      - "2003:2003"
   orleans-silo:
     image: orleans-silo
     build:

--- a/5a/docker-compose.override.yml
+++ b/5a/docker-compose.override.yml
@@ -11,6 +11,18 @@ services:
       - GATEWAYPORT=3001
     depends_on: 
       - orleans-silo
+      - orleans-silotwo
+  orleans-silotwo:
+    image: orleans-silo
+    build:
+      context: .
+      dockerfile: ./ops/SiloHost/Dockerfile
+    environment:
+      - ADVERTISEDIP=172.17.0.1
+      - SILOPORT=2003
+      - GATEWAYPORT=3003
+      - PRIMARYPORT=2001
+      - DASHBOARDPORT=8083
   orleans-silo:
     image: orleans-silo
     build:
@@ -18,8 +30,8 @@ services:
       dockerfile: ./ops/SiloHost/Dockerfile
     environment:
       - ADVERTISEDIP=172.17.0.1
-      - GATEWAYPORT=3001
       - SILOPORT=2001
+      - GATEWAYPORT=3001
       - PRIMARYPORT=2001
       - DASHBOARDPORT=8081
     ports:

--- a/5a/docker-compose.override.yml
+++ b/5a/docker-compose.override.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: ./ops/Client/Dockerfile
     environment:
-      - ADVERTISEDIP=172.28.190.64
+      - ADVERTISEDIP=172.17.0.1
       - GATEWAYPORT=3001
     depends_on: 
       - orleans-silo
@@ -17,7 +17,7 @@ services:
       context: .
       dockerfile: ./ops/SiloHost/Dockerfile
     environment:
-      - ADVERTISEDIP=172.28.190.64
+      - ADVERTISEDIP=172.17.0.1
       - GATEWAYPORT=3001
       - SILOPORT=2001
       - PRIMARYPORT=2001

--- a/5a/docker-compose.override.yml
+++ b/5a/docker-compose.override.yml
@@ -1,0 +1,28 @@
+version: '3.1'
+
+services:
+  orleans-client:
+    image: orleans-client
+    build:
+      context: .
+      dockerfile: ./ops/Client/Dockerfile
+    environment:
+      - ADVERTISEDIP=172.28.190.64
+      - GATEWAYPORT=3001
+    depends_on: 
+      - orleans-silo
+  orleans-silo:
+    image: orleans-silo
+    build:
+      context: .
+      dockerfile: ./ops/SiloHost/Dockerfile
+    environment:
+      - ADVERTISEDIP=172.28.190.64
+      - GATEWAYPORT=3001
+      - SILOPORT=2001
+      - PRIMARYPORT=2001
+      - DASHBOARDPORT=8081
+    ports:
+      - "8081:8081"
+      - "3001:3001"
+      - "2001:2001"

--- a/5a/docker-compose.yml
+++ b/5a/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.1'
+
+services:
+  orleans-client:
+    image: orleans-client
+    depends_on: 
+      - orleans-silo
+  orleans-silo:
+    image: orleans-silo

--- a/5a/docker-compose.yml
+++ b/5a/docker-compose.yml
@@ -1,8 +1,18 @@
+version: '2.1'
 services:
   orleans-client:
     image: orleans-client
-    depends_on: 
-      orleans-silo:
-        condition: service_healthy
+    depends_on:
+      - orleans-silo
+  orleans-silotwo:
+    image: orleans-silo
+    depends_on:
+      - orleans-silo
+#        condition: service_healthy
   orleans-silo:
     image: orleans-silo
+#    healthcheck:
+#      test: ["CMD", "curl", "-f", "http://Administrator:password@localhost:8091/pools/default/buckets/default"]
+#      interval: 10s
+#      timeout: 5s
+#      retries: 5

--- a/5a/docker-compose.yml
+++ b/5a/docker-compose.yml
@@ -1,18 +1,7 @@
-version: '2.1'
 services:
   orleans-client:
     image: orleans-client
     depends_on:
       - orleans-silo
-  orleans-silotwo:
-    image: orleans-silo
-    depends_on:
-      - orleans-silo
-#        condition: service_healthy
   orleans-silo:
     image: orleans-silo
-#    healthcheck:
-#      test: ["CMD", "curl", "-f", "http://Administrator:password@localhost:8091/pools/default/buckets/default"]
-#      interval: 10s
-#      timeout: 5s
-#      retries: 5

--- a/5a/docker-compose.yml
+++ b/5a/docker-compose.yml
@@ -1,9 +1,8 @@
-version: '3.1'
-
 services:
   orleans-client:
     image: orleans-client
     depends_on: 
-      - orleans-silo
+      orleans-silo:
+        condition: service_healthy
   orleans-silo:
     image: orleans-silo


### PR DESCRIPTION
This is a starting point for using `docker-compose` instead (or in addition) to the example scripts. If we are happy with it, I can also update the readme to give the option to run the example using `docker-compose -f docker-compose-3Silos-1Client.yml up` and so on
Example with 3 Silos 1 Client:

![image](https://user-images.githubusercontent.com/20638889/157853595-79d2d078-b28b-408b-8bb7-1db3a3464bd4.png)

![image](https://user-images.githubusercontent.com/20638889/157853696-e8988250-09cb-4d8d-84b6-268e3da41a40.png)

Example with 2 Silos 1 Client:

![image](https://user-images.githubusercontent.com/20638889/157854213-c4b87d82-94ed-4232-8e28-97cafb9be153.png)

![image](https://user-images.githubusercontent.com/20638889/157854056-87be80a4-35d5-4c83-b921-1743056c1a12.png)
