### PR TITLE
Update 1 to Orleans 7

### DIFF
--- a/1/SiloHost/SiloHost.csproj
+++ b/1/SiloHost/SiloHost.csproj
@@ -2,20 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 	<ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.6.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.6.0" />
-    <PackageReference Include="Microsoft.Orleans.OrleansTelemetryConsumers.Linux" Version="3.6.0" />
-    <PackageReference Include="OrleansDashboard" Version="3.6.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="7.0.0" />
+    <PackageReference Include="OrleansDashboard" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/1/SiloHost/src/Program.cs
+++ b/1/SiloHost/src/Program.cs
@@ -20,7 +20,6 @@ namespace SiloHost
             return new HostBuilder()
                 .UseOrleans(siloBuilder =>
                 {
-                    siloBuilder.UseLinuxEnvironmentStatistics();
                     siloBuilder.UseDashboard(dashboardOptions =>
                     {
                         dashboardOptions.Username = "piotr";


### PR DESCRIPTION
Updating project 1 to Orleans 7.
I removed UseLinuxEnvironmentStatistics as it's been deprecated, and should be replaced with OpenTelemetry.
